### PR TITLE
Adding in metadata access counting test for Glue Catalog

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -298,6 +298,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -338,6 +344,7 @@
                                 <exclude>**/TestIcebergGlueCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestTrinoGlueCatalogTest.java</exclude>
                                 <exclude>**/TestSharedGlueMetastore.java</exclude>
+                                <exclude>**/TestIcebergGlueCatalogAccessOperations.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -402,6 +409,7 @@
                                 <include>**/TestIcebergGlueCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoGlueCatalogTest.java</include>
                                 <include>**/TestSharedGlueMetastore.java</include>
+                                <include>**/TestIcebergGlueCatalogAccessOperations.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/GlueMetastoreMethod.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/GlueMetastoreMethod.java
@@ -1,0 +1,91 @@
+package io.trino.plugin.iceberg;
+
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreApiStats;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+
+public enum GlueMetastoreMethod
+{
+    BATCH_CREATE_PARTITION,
+    BATCH_UPDATE_PARTITION,
+    CREATE_DATABASE,
+    CREATE_PARTITIONS,
+    CREATE_TABLE,
+    DELETE_COLUMN_STATISTICS_FOR_PARTITION,
+    DELETE_COLUMN_STATISTICS_FOR_TABLE,
+    DELETE_DATA_BASE,
+    DELETE_PARTITION,
+    DELETE_TABLE,
+    GET_COLUMN_STATISTICS_FOR_PARTITION,
+    GET_COLUMN_STATISTICS_FOR_TABLE,
+    GET_DATABASE,
+    GET_DATABASES,
+    GET_PARTITION,
+    GET_PARTITION_BY_NAME,
+    GET_PARTITION_NAMES,
+    GET_PARTITIONS,
+    GET_TABLE,
+    GET_TABLES,
+    UPDATE_COLUMN_STATISTICS_FOR_PARTITION,
+    UPDATE_COLUMN_STATISTICS_FOR_TABLE,
+    UPDATE_DATABASE,
+    UPDATE_PARTITION,
+    UPDATE_TABLE;
+
+    public GlueMetastoreApiStats getStatFrom(GlueMetastoreStats stats) {
+        switch (this) {
+            case BATCH_CREATE_PARTITION:
+                return stats.getBatchCreatePartition();
+            case BATCH_UPDATE_PARTITION:
+                return stats.getBatchUpdatePartition();
+            case CREATE_DATABASE:
+                return stats.getCreateDatabase();
+            case CREATE_PARTITIONS:
+                return stats.getCreatePartitions();
+            case CREATE_TABLE:
+                return stats.getCreateTable();
+            case DELETE_COLUMN_STATISTICS_FOR_PARTITION:
+                return stats.getDeleteColumnStatisticsForPartition();
+            case DELETE_COLUMN_STATISTICS_FOR_TABLE:
+                return stats.getDeleteColumnStatisticsForTable();
+            case DELETE_DATA_BASE:
+                return stats.getDeleteDatabase();
+            case DELETE_PARTITION:
+                return stats.getDeletePartition();
+            case DELETE_TABLE:
+                return stats.getDeleteTable();
+            case GET_COLUMN_STATISTICS_FOR_PARTITION:
+                return stats.getGetColumnStatisticsForPartition();
+            case GET_COLUMN_STATISTICS_FOR_TABLE:
+                return stats.getGetColumnStatisticsForTable();
+            case GET_DATABASE:
+                return stats.getGetDatabase();
+            case GET_DATABASES:
+                return stats.getGetDatabases();
+            case GET_PARTITION:
+                return stats.getGetPartition();
+            case GET_PARTITION_BY_NAME:
+                return stats.getGetPartitionByName();
+            case GET_PARTITION_NAMES:
+                return stats.getGetPartitionNames();
+            case GET_PARTITIONS:
+                return stats.getGetPartitions();
+            case GET_TABLE:
+                return stats.getGetTable();
+            case GET_TABLES:
+                return stats.getGetTables();
+            case UPDATE_COLUMN_STATISTICS_FOR_PARTITION:
+                return stats.getUpdateColumnStatisticsForPartition();
+            case UPDATE_COLUMN_STATISTICS_FOR_TABLE:
+                return stats.getUpdateColumnStatisticsForTable();
+            case UPDATE_DATABASE:
+                return stats.getUpdateDatabase();
+            case UPDATE_PARTITION:
+                return stats.getUpdatePartition();
+            case UPDATE_TABLE:
+                return stats.getUpdateTable();
+            default:
+                // Proper way to make this into trino exception?
+                throw new RuntimeException(String.format("Make Glue Metastore method %s has corresponding stat", this.name()));
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGlueCatalogAccessOperations.java
@@ -1,0 +1,456 @@
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Sets;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.plugin.iceberg.catalog.glue.GlueIcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalogFactory;
+import io.trino.spi.Plugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.CREATE_TABLE;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.GET_DATABASE;
+import static io.trino.plugin.iceberg.GlueMetastoreMethod.GET_TABLE;
+import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.plugin.iceberg.TableType.FILES;
+import static io.trino.plugin.iceberg.TableType.HISTORY;
+import static io.trino.plugin.iceberg.TableType.MANIFESTS;
+import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.PROPERTIES;
+import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+/*
+ * TestIcebergGlueCatalogAccessOperations currently uses AWS Default Credential Provider Chain,
+ * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * on ways to set your AWS credentials which will be needed to run this test.
+ */
+@Test(singleThreaded = true)
+public class TestIcebergGlueCatalogAccessOperations
+        extends AbstractTestQueryFramework
+{
+    private static AtomicReference<GlueMetastoreStats> catalogStatsPin;
+    private static AtomicReference<GlueMetastoreStats> tableOperationStatsPin;
+
+    private final String schema = "test_schema_" + randomTableSuffix();
+    private final Session TEST_SESSION = testSessionBuilder()
+            .setCatalog("iceberg")
+            .setSchema(schema)
+            .build();
+
+    private GlueMetastoreStats catalogStats;
+    private GlueMetastoreStats tableOperationStats;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        File tmp = Files.createTempDirectory("test_iceberg").toFile();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION).build();
+        Plugin plugin = new TestingIcebergPlugin(Optional.empty(), Optional.empty(), Optional.of(new StealStatsModule()));
+
+        queryRunner.installPlugin(plugin);
+        queryRunner.createCatalog("iceberg", "iceberg",
+                ImmutableMap.of(
+                        "iceberg.catalog.type", "glue",
+                        "hive.metastore.glue.default-warehouse-dir", tmp.getAbsolutePath()
+                ));
+        queryRunner.execute("CREATE SCHEMA " + schema);
+        catalogStats = catalogStatsPin.get();
+        tableOperationStats = tableOperationStatsPin.get();
+        return queryRunner;
+    }
+
+    @Test
+    public void testCreateTable()
+    {
+        try {
+            assertMetastoreInvocations("CREATE TABLE test_create (id VARCHAR, age INT)",
+                    ImmutableMultiset.builder()
+                            .add(CREATE_TABLE)
+                            .add(GET_DATABASE)
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_create");
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelect()
+    {
+        try {
+            assertMetastoreInvocations("CREATE TABLE test_ctas AS SELECT 1 AS age",
+                    ImmutableMultiset.builder()
+                            .add(GET_DATABASE)
+                            .add(CREATE_TABLE)
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_ctas");
+        }
+    }
+
+    @Test
+    public void testSelect()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_from (id VARCHAR, age INT)");
+            assertMetastoreInvocations("SELECT * FROM test_select_from",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_from");
+        }
+    }
+
+    @Test
+    public void testSelectWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_from_where AS SELECT 2 as age", 1);
+
+            assertMetastoreInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_from_where");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_view_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE VIEW test_select_view_view AS SELECT id, age FROM test_select_view_table");
+
+            assertMetastoreInvocations("SELECT * FROM test_select_view_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP VIEW IF EXISTS test_select_view_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromViewWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_view_where_table AS SELECT 2 as age", 1);
+            assertUpdate("CREATE VIEW test_select_view_where_view AS SELECT age FROM test_select_view_where_table");
+            assertMetastoreInvocations("SELECT * FROM test_select_view_where_view WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP VIEW IF EXISTS test_select_view_where_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_view_where_view");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromMaterializedView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_mview_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE MATERIALIZED VIEW test_select_mview_view AS SELECT id, age FROM test_select_mview_table");
+
+            assertMetastoreInvocations("SELECT * FROM test_select_mview_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 3)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_select_mview_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_mview_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromMaterializedViewWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_mview_where_table AS SELECT 2 as age", 1);
+            assertUpdate("CREATE MATERIALIZED VIEW test_select_mview_where_view AS SELECT age FROM test_select_mview_where_table");
+
+            assertMetastoreInvocations("SELECT * FROM test_select_mview_where_view WHERE age = 2",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 3)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_select_mview_where_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_mview_where_table");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testRefreshMaterializedView()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_refresh_mview_table (id VARCHAR, age INT)");
+            assertUpdate("CREATE MATERIALIZED VIEW test_refresh_mview_view AS SELECT id, age FROM test_refresh_mview_table");
+
+            assertMetastoreInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 5)
+                            //.addCopies(REPLACE_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS test_refresh_mview_view");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_refresh_mview_table");
+        }
+    }
+
+    @Test
+    public void testJoin()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_join_t1 AS SELECT 2 as age, 'id1' AS id", 1);
+            assertUpdate("CREATE TABLE test_join_t2 AS SELECT 'name1' as name, 'id1' AS id", 1);
+
+            assertMetastoreInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 2)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_join_t1");
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_join_t2");
+        }
+    }
+
+    @Test
+    public void testSelfJoin()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_self_join_table AS SELECT 2 as age, 0 parent, 3 AS id", 1);
+
+            assertMetastoreInvocations("SELECT child.age, parent.age FROM test_self_join_table child JOIN test_self_join_table parent ON child.parent = parent.id",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_self_join_table");
+        }
+    }
+
+    @Test
+    public void testExplainSelect()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_explain AS SELECT 2 as age", 1);
+
+            assertMetastoreInvocations("EXPLAIN SELECT * FROM test_explain",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_explain");
+        }
+    }
+
+    @Test
+    public void testShowStatsForTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_show_stats AS SELECT 2 as age", 1);
+
+            assertMetastoreInvocations("SHOW STATS FOR test_show_stats",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_show_stats");
+        }
+    }
+
+    @Test
+    public void testShowStatsForTableWithFilter()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_show_stats_with_filter AS SELECT 2 as age", 1);
+
+            assertMetastoreInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
+                    ImmutableMultiset.builder()
+                            .add(GET_TABLE)
+                            .build());
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_show_stats_with_filter");
+        }
+    }
+
+    @Test
+    public void testSelectSystemTable()
+    {
+        try {
+            assertUpdate("CREATE TABLE test_select_snapshots AS SELECT 2 AS age", 1);
+            // select from $history
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$history\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $snapshots
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$snapshots\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $manifests
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$manifests\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $partitions
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$partitions\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $files
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$files\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // select from $properties
+            assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
+                    ImmutableMultiset.builder()
+                            .addCopies(GET_TABLE, 1)
+                            .build());
+
+            // This test should get updated if a new system table is added.
+            assertThat(TableType.values())
+                    .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES);
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_select_snapshots");
+        }
+    }
+
+    private void assertMetastoreInvocations(@Language("SQL") String query, Multiset<?> expectedInvocations)
+    {
+        Map<GlueMetastoreMethod, Integer> startingCounts = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(Collectors.toMap(
+                                Function.identity(),
+                                method -> (int) method.getStatFrom(catalogStats).getTime().getAllTime().getCount() +
+                                        (int) method.getStatFrom(tableOperationStats).getTime().getAllTime().getCount()
+                        )
+                );
+
+        getQueryRunner().execute(query);
+        Map<GlueMetastoreMethod, Integer> endingCounts = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(Collectors.toMap(
+                                Function.identity(),
+                                method -> (int) method.getStatFrom(catalogStats).getTime().getAllTime().getCount() +
+                                        (int) method.getStatFrom(tableOperationStats).getTime().getAllTime().getCount()
+                        )
+                );
+
+        Map<GlueMetastoreMethod, Integer> deltas = Arrays.stream(GlueMetastoreMethod.values())
+                .collect(Collectors.toMap(Function.identity(), method -> endingCounts.get(method) - startingCounts.get(method)));
+        ImmutableMultiset.Builder<GlueMetastoreMethod> builder = ImmutableMultiset.builder();
+        deltas.entrySet().stream().filter(entry -> entry.getValue() > 0).forEach(entry -> builder.setCount(entry.getKey(), entry.getValue()));
+        Multiset<GlueMetastoreMethod> actualInvocations = builder.build();
+
+        if (expectedInvocations.equals(actualInvocations)) {
+            return;
+        }
+
+        List<String> mismatchReport = Sets.union(expectedInvocations.elementSet(), actualInvocations.elementSet()).stream()
+                .filter(key -> expectedInvocations.count(key) != actualInvocations.count(key))
+                .flatMap(key -> {
+                    int expectedCount = expectedInvocations.count(key);
+                    int actualCount = actualInvocations.count(key);
+                    if (actualCount < expectedCount) {
+                        return Stream.of(format("%s more occurrences of %s", expectedCount - actualCount, key));
+                    }
+                    if (actualCount > expectedCount) {
+                        return Stream.of(format("%s fewer occurrences of %s", actualCount - expectedCount, key));
+                    }
+                    return Stream.of();
+                })
+                .collect(toImmutableList());
+
+        fail("Expected: \n\t\t" + join(",\n\t\t", mismatchReport));
+    }
+
+    @AfterClass
+    public void cleanUpSchema()
+            throws Exception
+    {
+        getQueryRunner().execute("DROP SCHEMA IF EXISTS " + schema);
+    }
+
+    static class TheStatsBurgler
+    {
+        @Inject
+        TheStatsBurgler(TrinoCatalogFactory factory, IcebergTableOperationsProvider provider)
+        {
+            verify(factory instanceof TrinoGlueCatalogFactory, "Must use this module with the configuration of iceberg.catalog.type=glue");
+            TestIcebergGlueCatalogAccessOperations.catalogStatsPin = new AtomicReference<>(((TrinoGlueCatalogFactory) factory).getStats());
+            verify(provider instanceof GlueIcebergTableOperationsProvider, "Must use this module with the configuration of iceberg.catalog.type=glue");
+            TestIcebergGlueCatalogAccessOperations.tableOperationStatsPin = new AtomicReference<>(((GlueIcebergTableOperationsProvider) provider).getStats());
+        }
+    }
+
+    class StealStatsModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            // Eager singleton to make singleton immediately as a dummy object to trigger code that will extract the stats out of the catalog factory
+            binder.bind(TheStatsBurgler.class).asEagerSingleton();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.inject.Module;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
@@ -30,11 +31,18 @@ public class TestingIcebergConnectorFactory
 {
     private final Optional<HiveMetastore> metastore;
     private final Optional<FileIoProvider> fileIoProvider;
+    private final Optional<Module> module;
 
     public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider)
     {
+        this(metastore, fileIoProvider, Optional.empty());
+    }
+
+    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider, Optional<Module> module)
+    {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.module = requireNonNull(module, "module is null");
     }
 
     @Override
@@ -46,6 +54,6 @@ public class TestingIcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, EMPTY_MODULE, metastore, fileIoProvider);
+        return createConnector(catalogName, config, context, module.orElse(EMPTY_MODULE), metastore, fileIoProvider);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.ConnectorFactory;
 
@@ -28,11 +29,18 @@ public class TestingIcebergPlugin
 {
     private final Optional<HiveMetastore> metastore;
     private final Optional<FileIoProvider> fileIoProvider;
+    private final Optional<Module> module;
 
     public TestingIcebergPlugin(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider)
     {
+        this(metastore, fileIoProvider, Optional.empty());
+    }
+
+    public TestingIcebergPlugin(Optional<HiveMetastore> metastore, Optional<FileIoProvider> fileIoProvider, Optional<Module> module)
+    {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.module = requireNonNull(module, "module is null");
     }
 
     @Override
@@ -41,6 +49,6 @@ public class TestingIcebergPlugin
         List<ConnectorFactory> connectorFactories = ImmutableList.copyOf(super.getConnectorFactories());
         verify(connectorFactories.size() == 1, "Unexpected connector factories: %s", connectorFactories);
 
-        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore, fileIoProvider));
+        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore, fileIoProvider, module));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

Add in a test to count meta data class to Glue during standard Iceberg Catalog calls. Copying tests from analogous Iceberg with HiveMetastore test.
<!-- Elaborate beyond the title of the PR as necessary to help the reviewers and maintainers.-->

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
improvement 

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
tests

> How would you describe this change to a non-technical end user or system administrator?
ensuring consistent/reasonable metadata service dependency during Iceberg operation. 

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

(X ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

(X ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
